### PR TITLE
hide drag image from top left of screen before move event starts

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -70,7 +70,7 @@
         pageXs.push(touch.pageX);
         pageYs.push(touch.pageY);
       });
-
+      this.showDragImage();
       this.dragImage.style["left"] = average(pageXs) - (parseInt(this.dragImage.offsetWidth, 10) / 2) + "px";
       this.dragImage.style["top"] = average(pageYs) - (parseInt(this.dragImage.offsetHeight, 10) / 2) + "px";
 
@@ -230,6 +230,7 @@
       this.dragImage.style["z-index"] = "999999";
       this.dragImage.style["pointer-events"] = "none";
       doc.body.appendChild(this.dragImage);
+      this.hideDragImage();
     }
   }
 


### PR DESCRIPTION
when the touch event is initiated, the drag image is created and appended to the document body, and it shows at the top left of the screen. once the move event starts, the drag image moves and follows the user's finger. this change hides the drag image from the moment of its creation until the beginning of the move event.