### PR TITLE
Only duplicate styles of elements.

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -284,19 +284,18 @@
     return el.addEventListener(event,listener);
   }
 
+  // duplicateStyle expects dstNode to be a clone of srcNode
   function duplicateStyle(srcNode, dstNode) {
     // Is this node an element?
-    if (dstNode.nodeType == 1) {
+    if (srcNode.nodeType == 1) {
       // Remove any potential conflict attributes
       dstNode.removeAttribute("id");
       dstNode.removeAttribute("class");
       dstNode.removeAttribute("style");
       dstNode.removeAttribute("draggable");
-    }
 
-    // Clone the style
-    var cs = window.getComputedStyle(srcNode);
-    if (cs) {
+      // Clone the style
+      var cs = window.getComputedStyle(srcNode);
       for (var i = 0; i < cs.length; i++) {
         var csName = cs[i];
         dstNode.style.setProperty(csName, cs.getPropertyValue(csName), cs.getPropertyPriority(csName));


### PR DESCRIPTION
Previous usage of ```window.getComputedStyle``` wasn't correct according to [the spec](https://developer.mozilla.org/en/docs/Web/API/window.getComputedStyle), which states: passing a non-Element Node, like a #text Node, will throw an error.

The old code (checking if a value was returned) did work, and still does on the latest iOS Safari. However the latest desktop Chrome touch emulation has started throwing an exception. This patch solves that problem.