### PR TITLE
Dealing with Android's lying.

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -13,7 +13,7 @@
     var dragDiv = 'draggable' in div;
     var evts = 'ondragstart' in div && 'ondrop' in div;
 
-    var needsPatch = !(dragDiv || evts) || /iPad|iPhone|iPod/.test(navigator.userAgent);
+    var needsPatch = !(dragDiv || evts) || /iPad|iPhone|iPod|Android/.test(navigator.userAgent);
     log((needsPatch ? "" : "not ") + "patching html5 drag drop");
 
     if(!needsPatch) return;


### PR DESCRIPTION
As we've been discussing in several threads, and lately in #40 - the Android browser, like the iOS browser, is lying about its drag event support and thus user-agent sniffing is required to still force the patch.