### PR TITLE
Fix inconsistencies & clean code

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -16,7 +16,9 @@
     var needsPatch = !(dragDiv || evts) || /iPad|iPhone|iPod|Android/.test(navigator.userAgent);
     log((needsPatch ? "" : "not ") + "patching html5 drag drop");
 
-    if(!needsPatch) return;
+    if(!needsPatch) {
+        return;
+    }
 
     if(!config.enableEnterLeave) {
       DragDrop.prototype.synthesizeEnterLeave = noop;
@@ -307,8 +309,9 @@
   }
 
   function onEvt(el, event, handler, context) {
-    if(context)
+    if(context) {
       handler = handler.bind(context);
+    }
     el.addEventListener(event, handler);
     return {
       off: function() {
@@ -318,8 +321,9 @@
   }
 
   function once(el, event, handler, context) {
-    if(context)
+    if(context) {
       handler = handler.bind(context);
+    }
     function listener(evt) {
       handler(evt);
       return el.removeEventListener(event,listener);

--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -32,14 +32,14 @@
     this.dragImage = null;
     this.dragImageTransform = null;
     this.dragImageWebKitTransform = null;
-    this.el = el || event.target
+    this.el = el || event.target;
 
     log("dragstart");
 
-    this.dispatchDragStart()
+    this.dispatchDragStart();
     this.createDragImage();
 
-    this.listen()
+    this.listen();
 
   }
 
@@ -56,7 +56,7 @@
       function cleanup() {
         log("cleanup");
         this.dragDataTypes = [];
-        if (this.dragImage != null) {
+        if (this.dragImage !== null) {
           this.dragImage.parentNode.removeChild(this.dragImage);
           this.dragImage = null;
           this.dragImageTransform = null;
@@ -70,7 +70,7 @@
     },
     move: function(event) {
       var pageXs = [], pageYs = [];
-      [].forEach.call(event.changedTouches, function(touch, index) {
+      [].forEach.call(event.changedTouches, function(touch) {
         pageXs.push(touch.pageX);
         pageYs.push(touch.pageY);
       });
@@ -82,14 +82,14 @@
       this.synthesizeEnterLeave(event);
     },
     hideDragImage: function() {
-      if (this.dragImage && this.dragImage.style["display"] != "none") {
-        this.dragImageDisplay = this.dragImage.style["display"];
-        this.dragImage.style["display"] = "none";
+      if (this.dragImage && this.dragImage.style.display != "none") {
+        this.dragImageDisplay = this.dragImage.style.display;
+        this.dragImage.style.display = "none";
       }
     },
     showDragImage: function() {
       if (this.dragImage) {
-        this.dragImage.style["display"] = this.dragImageDisplay ? this.dragImageDisplay : "block";
+        this.dragImage.style.display = this.dragImageDisplay ? this.dragImageDisplay : "block";
       }
     },
     // We use translate instead of top/left because of sub-pixel rendering and for the hope of better performance
@@ -101,12 +101,12 @@
         this.dragImage.style["-webkit-transform"] = this.dragImageWebKitTransform + translate;
       }
       if (this.dragImageTransform !== null) {
-        this.dragImage.style["transform"] = this.dragImageTransform + translate;
+        this.dragImage.style.transform = this.dragImageTransform + translate;
       }
     },
     synthesizeEnterLeave: function(event) {
       this.hideDragImage();
-      var target = elementFromTouchEvent(this.el,event)
+      var target = elementFromTouchEvent(this.el,event);
       this.showDragImage();
       if (target != this.lastEnter) {
         if (this.lastEnter) {
@@ -132,14 +132,14 @@
       }
 
       this.hideDragImage();
-      var target = elementFromTouchEvent(this.el,event)
+      var target = elementFromTouchEvent(this.el,event);
       this.showDragImage();
 
       if (target) {
         log("found drop target " + target.tagName);
-        this.dispatchDrop(target, event)
+        this.dispatchDrop(target, event);
       } else {
-        log("no drop target")
+        log("no drop target");
       }
 
       var dragendEvt = doc.createEvent("Event");
@@ -244,14 +244,15 @@
       
       duplicateStyle(this.el, this.dragImage);
       
-      this.dragImage.style["opacity"] = "0.5";
-      this.dragImage.style["position"] = "absolute";
-      this.dragImage.style["left"] = "0px";
-      this.dragImage.style["top"] = "0px";
-      this.dragImage.style["z-index"] = "999999";
-      this.dragImage.style["pointer-events"] = "none";
+      this.dragImage.style.opacity = "0.5";
+      this.dragImage.style.position = "absolute";
+      this.dragImage.style.left = "0px";
+      this.dragImage.style.top = "0px";
+      this.dragImage.style.zIndex = "999999";
+      this.dragImage.style.pointerEvents = "none";
 
-      var transform = this.dragImage.style["transform"];
+
+      var transform = this.dragImage.style.transform;
       if (typeof transform !== "undefined") {
         this.dragImageTransform = "";
         if (transform != "none") {
@@ -271,7 +272,7 @@
 
       doc.body.appendChild(this.dragImage);
     }
-  }
+  };
 
   // event listeners
   function touchstart(evt) {
@@ -292,7 +293,7 @@
         evt.preventDefault();
         new DragDrop(evt,el);
       }
-    } while((el = el.parentNode) && el !== doc.body)
+    } while((el = el.parentNode) && el !== doc.body);
   }
 
   // DOM helpers
@@ -302,11 +303,12 @@
       touch[coordinateSystemForElementFromPoint + "X"],
       touch[coordinateSystemForElementFromPoint + "Y"]
     );
-    return target
+    return target;
   }
 
   function onEvt(el, event, handler, context) {
-    if(context) handler = handler.bind(context)
+    if(context)
+      handler = handler.bind(context);
     el.addEventListener(event, handler);
     return {
       off: function() {
@@ -316,7 +318,8 @@
   }
 
   function once(el, event, handler, context) {
-    if(context) handler = handler.bind(context)
+    if(context)
+      handler = handler.bind(context);
     function listener(evt) {
       handler(evt);
       return el.removeEventListener(event,listener);
@@ -344,8 +347,8 @@
 
     // Do the same for the children
     if (srcNode.hasChildNodes()) {
-      for (var i = 0; i < srcNode.childNodes.length; i++) {
-        duplicateStyle(srcNode.childNodes[i], dstNode.childNodes[i]);
+      for (var j = 0; j < srcNode.childNodes.length; j++) {
+        duplicateStyle(srcNode.childNodes[j], dstNode.childNodes[j]);
       }
     }
   }


### PR DESCRIPTION
Inconsistent semicolons, duplicate variables, unused variables, dot notation, etc.

JSHint complained a shit ton about this:

25 warnings
35	Missing semicolon.
39	Missing semicolon.
42	Missing semicolon.
60	Use '!==' to compare with 'null'.
87	['display'] is better written in dot notation.
88	['display'] is better written in dot notation.
89	['display'] is better written in dot notation.
94	['display'] is better written in dot notation.
106	['transform'] is better written in dot notation.
111	Missing semicolon.
137	Missing semicolon.
142	Missing semicolon.
144	Missing semicolon.
249	['opacity'] is better written in dot notation.
250	['position'] is better written in dot notation.
251	['left'] is better written in dot notation.
252	['top'] is better written in dot notation.
256	['transform'] is better written in dot notation.
276	Missing semicolon.
296	Do not use 'new' for side effects.
298	Missing semicolon.
309	Missing semicolon.
313	Missing semicolon.
323	Missing semicolon.
353	'i' is already defined.
Two unused variables
75	index
303	el