### PR TITLE
Made elementFromPoint work again in iOS 8.4.1.

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -81,17 +81,6 @@
 
       this.synthesizeEnterLeave(event);
     },
-    hideDragImage: function() {
-      if (this.dragImage && this.dragImage.style["display"] != "none") {
-        this.dragImageDisplay = this.dragImage.style["display"];
-        this.dragImage.style["display"] = "none";
-      }
-    },
-    showDragImage: function() {
-      if (this.dragImage) {
-        this.dragImage.style["display"] = this.dragImageDisplay ? this.dragImageDisplay : "block";
-      }
-    },
     // We use translate instead of top/left because of sub-pixel rendering and for the hope of better performance
     // http://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/
     translateDragImage: function(x, y) {
@@ -105,9 +94,7 @@
       }
     },
     synthesizeEnterLeave: function(event) {
-      this.hideDragImage();
       var target = elementFromTouchEvent(this.el,event)
-      this.showDragImage();
       if (target != this.lastEnter) {
         if (this.lastEnter) {
           this.dispatchLeave(event);
@@ -131,10 +118,7 @@
         this.dispatchLeave(event);
       }
 
-      this.hideDragImage();
       var target = elementFromTouchEvent(this.el,event)
-      this.showDragImage();
-
       if (target) {
         log("found drop target " + target.tagName);
         this.dispatchDrop(target, event)
@@ -249,7 +233,6 @@
       this.dragImage.style["left"] = "0px";
       this.dragImage.style["top"] = "0px";
       this.dragImage.style["z-index"] = "999999";
-      this.dragImage.style["pointer-events"] = "none";
 
       var transform = this.dragImage.style["transform"];
       if (typeof transform !== "undefined") {
@@ -340,6 +323,9 @@
         var csName = cs[i];
         dstNode.style.setProperty(csName, cs.getPropertyValue(csName), cs.getPropertyPriority(csName));
       }
+
+      // Pointer events as none makes the drag image transparent to document.elementFromPoint()
+      dstNode.style.pointerEvents = "none";
     }
 
     // Do the same for the children


### PR DESCRIPTION
As reported in issue #46 the library stopped working properly in iOS 8.4.1 Safari. As @ishmaelAhmed pointed out there, ```document.elementFromPoint()``` seems broken now. It returns some ancestor element of the element we actually want. I found out that [Dragula also has users suffering from this issue](https://github.com/bevacqua/dragula/issues/164).

Both @ishmaelAhmed and Dragula people had some proof of concept fixes by messing around with styles. Thankfully @NoelAbrahams mentioned that the new fork discussed in #44 doesn't suffer from this problem. That fork also uses ```document.elementFromPoint()``` so I dove in to find out what exactly is the difference maker here.

Turns out that iOS 8.4.1 gets confused if an element's ```display``` has been just recently changed. We used to hide the drag image, use ```document.elementFromPoint()```, show the drag image again. This works fine up to iOS 8.4. In iOS 8.4.1 however, it returns a parent element of the element we care about. This is so even if the drag image's ```pointer-events``` are set to ```none```!! It starts occasionally working properly when I add a 200ms delay between hiding the drag image and using ```document.elementFromPoint()```. It works every time when I don't show the drag image at all.

So it seems to me that iOS 8.4.1 Safari has a dirty state immedately after changing ```display``` and ```document.elementFromPoint()``` gets confused because of that.

The solution, and included in this pull request, is to set ```pointer-events``` to ```none``` on every sub-element of the drag image and thus be able to completely remove the hide/show code that is messing up Safari in iOS 8.4.1.