### PR TITLE
Add dropEffect 'move' to event.DataTransfer on dispatchDrop

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -146,7 +146,8 @@
         types: this.dragDataTypes,
         getData: function(type) {
           return this.dragData[type];
-        }.bind(this)
+        }.bind(this),
+        dropEffect: "move"
       };
       dropEvt.preventDefault = function() {
          // https://www.w3.org/Bugs/Public/show_bug.cgi?id=14638 - if we don't cancel it, we'll snap back


### PR DESCRIPTION
As mentioned in issue #54, the event generated by dispatchDrop does not contain a dropEffect, which breaks the interaction with angular-drag-and-drop-lists. 