### PR TITLE
Support for canceling the dragstart event

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -41,11 +41,10 @@
 
     log("dragstart");
 
-    this.dispatchDragStart();
-    this.createDragImage();
-
-    this.listen();
-
+    if (this.dispatchDragStart()) {
+      this.createDragImage();
+      this.listen();
+    }
   }
 
   DragDrop.prototype = {
@@ -234,7 +233,7 @@
         }.bind(this),
         dropEffect: "move"
       };
-      this.el.dispatchEvent(evt);
+      return this.el.dispatchEvent(evt);
     },
     createDragImage: function() {
       if (this.customDragImage) {


### PR DESCRIPTION
According to [the spec](https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model) (6.7.5.9) and as pointed out by @loopingLines in issue #57, the `dragstart` event is cancelable.

This patch implements this requirement.