### PR TITLE
Stop after finding first draggable element

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -290,6 +290,7 @@
         }
         evt.preventDefault();
         new DragDrop(evt,el);
+        break;
       }
     } while((el = el.parentNode) && el !== doc.body);
   }


### PR DESCRIPTION
Currently if we have a draggable inside a draggable, both are selected and move, not just the top one.
This PR stops creating `new DragDrop()` objects after the first.