### PR TITLE
Search upwards for a draggable element in touchstartDelay

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -292,27 +292,30 @@
     return function(evt){
       var el = evt.target;
 
-      if (el.draggable === true) {
-        var heldItem = function() {
-          end.off();
-          cancel.off();
-          scroll.off();
-          touchstart(evt);
-        };
+      do {
+        if (el.draggable === true) {
+          var heldItem = function() {
+            end.off();
+            cancel.off();
+            scroll.off();
+            touchstart(evt);
+          };
 
-        var onReleasedItem = function() {
-          end.off();
-          cancel.off();
-          scroll.off();
-          clearTimeout(timer);
-        };
+          var onReleasedItem = function() {
+            end.off();
+            cancel.off();
+            scroll.off();
+            clearTimeout(timer);
+          };
 
-        var timer = setTimeout(heldItem, delay);
+          var timer = setTimeout(heldItem, delay);
 
-        var end = onEvt(el, 'touchend', onReleasedItem, this);
-        var cancel = onEvt(el, 'touchcancel', onReleasedItem, this);
-        var scroll = onEvt(window, 'scroll', onReleasedItem, this);
-      }
+          var end = onEvt(el, 'touchend', onReleasedItem, this);
+          var cancel = onEvt(el, 'touchcancel', onReleasedItem, this);
+          var scroll = onEvt(window, 'scroll', onReleasedItem, this);
+          break;
+        }        
+      } while ((el = el.parentNode) && el !== doc.body);
     };
   };
 


### PR DESCRIPTION
#75 added a very useful ability to delay dragging, but it only works if the direct target of the first touch is itself draggable. This patch adds a search up the tree for a draggable element, just like how `touchstart` does. This makes dragging work on my project :-).