### PR TITLE
Simple fix to new Chrome 'feature' that causes issues with scroll while dragging

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -25,10 +25,10 @@
     }
 
     if(config.holdToDrag){
-      doc.addEventListener("touchstart", touchstartDelay(config.holdToDrag));
+      doc.addEventListener("touchstart", touchstartDelay(config.holdToDrag), {passive:false});
     }
     else {
-      doc.addEventListener("touchstart", touchstart);
+      doc.addEventListener("touchstart", touchstart, {passive:false});
     }
   }
 
@@ -362,7 +362,7 @@
     if(context) {
       handler = handler.bind(context);
     }
-    el.addEventListener(event, handler);
+    el.addEventListener(event, handler, {passive:false});
     return {
       off: function() {
         return el.removeEventListener(event, handler);


### PR DESCRIPTION
Introduced by Chrome v56 in late Jan / early Feb of 2017:
https://www.chromestatus.com/features/5093566007214080
https://developers.google.com/web/updates/2017/01/scrolling-intervention

There are two ways to deal with this change: use the css property 'touch-action' to disable panning (ie: scrolling in this case), or update the library to allow for preventDefault() by using {passive:false} in our addEventListener invocation.

In our case I believe {passive:false} is the right answer, because there may be times when we want the draggable items/region to be scrollable, when using the holdToDrag option.

I believe @reppners saw this coming via the canary builds last year and has this fixed the beta.  This PR is sort of an emergency-fix to those on the current version (like me!)