### PR TITLE
Fix license variables to show MIT

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "git://github.com/timruffles/ios-html5-drag-drop-shim.git"
   },
-  "license": "BSD-2-Clause",
+  "license": "MIT",
   "moduleType": [
     "globals"
   ]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "mobile"
   ],
   "author": "Tim Ruffles <me@truffles.me.uk>",
-  "license": "BSD-2-Clause",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/timruffles/ios-html5-drag-drop-shim/issues"
   },


### PR DESCRIPTION
Based on the [LICENSE](https://github.com/timruffles/ios-html5-drag-drop-shim/blob/f0f98300d5faf3179476078f0c411fc9c7e4fa03/LICENSE) file and [README](https://github.com/timruffles/ios-html5-drag-drop-shim/blob/f0f98300d5faf3179476078f0c411fc9c7e4fa03/README.md#license) this project is using MIT. This PR makes sure this is correctly reflected in `package.json` & `bower.json`.