### PR TITLE
Added 'passive' option to removeEventListener call (to match addEventListener call). Fixes bug in iOS 9

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -390,7 +390,7 @@ function _exposeIosHtml5DragDropShim(config) {
     el.addEventListener(event, handler, {passive:false});
     return {
       off: function() {
-        return el.removeEventListener(event, handler);
+        return el.removeEventListener(event, handler, {passive:false});
       }
     };
   }


### PR DESCRIPTION
  Without this fix the listener removal doesn't work in older versions of Safari, and this causes some real problems.