### PR TITLE
Pass the evento to the handleTouchStartOnAnchor to fix bug

### DIFF
--- a/ios-drag-drop.js
+++ b/ios-drag-drop.js
@@ -342,7 +342,7 @@ function _exposeIosHtml5DragDropShim(config) {
     var el = evt.target;
     do {
       if (elementIsDraggable(el)) {
-        handleTouchStartOnAnchor(el);
+        handleTouchStartOnAnchor(evt, el);
 
         evt.preventDefault();
         new DragDrop(evt,el);
@@ -366,7 +366,7 @@ function _exposeIosHtml5DragDropShim(config) {
     return el.tagName.toLowerCase() == "a";
   }
 
-  function handleTouchStartOnAnchor(el){
+  function handleTouchStartOnAnchor(evt, el){
     // If draggable isn't explicitly set for anchors, then simulate a click event.
     // Otherwise plain old vanilla links will stop working.
     // https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Touch_events#Handling_clicks


### PR DESCRIPTION
See https://github.com/timruffles/ios-html5-drag-drop-shim/issues/95