### PR TITLE
Skip dragend timeout if no snapback is used

### DIFF
--- a/src/drag-drop-polyfill.ts
+++ b/src/drag-drop-polyfill.ts
@@ -1387,6 +1387,16 @@ module DragDropPolyfill {
             transitionEndCb();
             return;
         }
+        // add class containing transition rules
+        dragImage.classList.add( CLASS_DRAG_IMAGE_SNAPBACK );
+
+        const csDragImage = getComputedStyle( dragImage );
+        const durationInS = parseFloat( csDragImage.transitionDuration );
+        if (durationInS === NaN || durationInS ====0) {
+            console.log( "dnd-poly: no transition used - skipping snapback" );
+            transitionEndCb();
+            return;
+        }
 
         console.log( "dnd-poly: starting dragimage snap back" );
 
@@ -1406,11 +1416,6 @@ module DragDropPolyfill {
         pnt.x -= parseInt( cs.marginLeft, 10 );
         pnt.y -= parseInt( cs.marginTop, 10 );
 
-        // add class containing transition rules
-        dragImage.classList.add( CLASS_DRAG_IMAGE_SNAPBACK );
-
-        const csDragImage = getComputedStyle( dragImage );
-        const durationInS = parseFloat( csDragImage.transitionDuration );
         const delayInS = parseFloat( csDragImage.transitionDelay );
         const durationInMs = Math.round( (durationInS + delayInS) * 1000 );
 

--- a/src/drag-drop-polyfill.ts
+++ b/src/drag-drop-polyfill.ts
@@ -1392,7 +1392,7 @@ module DragDropPolyfill {
 
         const csDragImage = getComputedStyle( dragImage );
         const durationInS = parseFloat( csDragImage.transitionDuration );
-        if (durationInS === NaN || durationInS ====0) {
+        if (isNan(durationInS) || durationInS ===0) {
             console.log( "dnd-poly: no transition used - skipping snapback" );
             transitionEndCb();
             return;

--- a/src/drag-drop-polyfill.ts
+++ b/src/drag-drop-polyfill.ts
@@ -1392,7 +1392,7 @@ module DragDropPolyfill {
 
         const csDragImage = getComputedStyle( dragImage );
         const durationInS = parseFloat( csDragImage.transitionDuration );
-        if (isNan(durationInS) || durationInS ===0) {
+        if (isNaN(durationInS) || durationInS ===0) {
             console.log( "dnd-poly: no transition used - skipping snapback" );
             transitionEndCb();
             return;


### PR DESCRIPTION
It should be optional to use the "snapback" UX feature when user has not dropped to a valid drop zone.

This change just simply checks that is there a transition duration applied, and if not, then skips the unnecessary timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/timruffles/ios-html5-drag-drop-shim/99)
<!-- Reviewable:end -->
